### PR TITLE
Added a detection rule for PBot

### DIFF
--- a/webshells/pbot.yar
+++ b/webshells/pbot.yar
@@ -1,0 +1,20 @@
+rule pbot
+{
+    meta:
+        description = "PHP IRC Bot"
+        family = "Backdoor.PHP.Pbot"
+        filetype = "PHP"
+        hash = "cd62b4c32f0327d06dd99648e44c85560416a40f6734429d3e89a4c5250fd28e"
+        hash = "80fb661aac9fcfbb5ae356c5adc7d403bf15da9432b5e33fbbed938c42fdde3c"
+        hash = "6873bcc7f3971c42564a5fb72d5963b1660c6ff53409e496695523c1115e9734"
+
+    strings:
+        $class = "class pBot" ascii
+        $start = "function start(" ascii
+        $ping = "PING" ascii
+        $pong = "PONG" ascii
+
+    condition:
+        all of them
+}
+


### PR DESCRIPTION
I added a rule for the PBot webshell / IRC Bot. This webshell is both old and still used. Reference: http://telussecuritylabs.com/threats/show/TSL20140326-08

I tested this against three variants:

1. PBot "embedded" in a gif (aka byroe.jpg) 
2. Generic PBot
3. Windows specific PBot

To simplify our first commit, I intentionally did *not* detect the obfuscated version:

1. https://www.cyphort.com/threat-insights/backdoor-pbot/
2. https://www.rapid7.com/db/modules/exploit/multi/misc/pbot_exec

Finally, I went with four unique meta fields. I think they are all obvious except perhaps the "hash". These are sample hashes that the rule will trigger on. For example:

https://www.virustotal.com/en/file/cd62b4c32f0327d06dd99648e44c85560416a40f6734429d3e89a4c5250fd28e/analysis/