### PR TITLE
Added detection for FOPO and eval obfuscation as well as a generic JSP

### DIFF
--- a/webshells/fopo.yar
+++ b/webshells/fopo.yar
@@ -1,0 +1,17 @@
+rule fopo
+{
+    meta:
+        description = "Free Online PHP Obfuscator"
+        family = "PHP.Obfuscated"
+        filetype = "PHP"
+        hash = "b96a81b71d69a9bcb5a3f9f4edccb4a3c7373159d8eda874e053b23d361107f0"
+        hash = "bbe5577639233b5a83c4caebf807c553430cab230f9a15ec519670dd8be6a924"
+        hash = "a698441f817a9a72908a0d93a34133469f33a7b34972af3e351bdccae0737d99"
+
+    strings:
+        $base64_decode = /\$[a-zA-Z0-9]+=\"\\(142|x62)\\(141|x61)\\(163|x73)\\(145|x65)\\(66|x36)\\(64|x34)\\(137|x5f)\\(144|x64)\\(145|x65)\\(143|x63)\\(157|x6f)\\(144|x64)\\(145|x65)\";@eval\(/
+
+    condition:
+        all of them
+}
+

--- a/webshells/generic_jsp.yar
+++ b/webshells/generic_jsp.yar
@@ -1,0 +1,14 @@
+rule generic_jsp
+{
+    meta:
+        description = "Generic JSP"
+        family = "JSP Backdoor"
+        filetype = "JSP"
+        hash = "6517e4c8f19243298949711b48ae2eb0b6c764235534ab29603288bc5fa2e158"
+
+    strings:
+        $exec = /Runtime.getRuntime\(\).exec\(request.getParameter\(\"[a-zA-Z0-9]+\"\)\);/ ascii
+
+    condition:
+        all of them
+}

--- a/webshells/obfuscated_php.yar
+++ b/webshells/obfuscated_php.yar
@@ -1,0 +1,17 @@
+rule eval_statement
+{
+    meta:
+        description = "Obfuscated PHP eval statements"
+        family = "PHP.Obfuscated"
+        filetype = "PHP"
+        hash = "9da32d35a28d2f8481a4e3263e2f0bb3836b6aebeacf53cd37f2fe24a769ff52"
+        hash = "8c1115d866f9f645788f3689dff9a5bacfbee1df51058b4161819c750cf7c4a1"
+        hash = "14083cf438605d38a206be33542c7a4d48fb67c8ca0cfc165fa5f279a6d55361"
+
+    strings:
+        $obf = /eval[\( \t]+((base64_decode[\( \t]+)|(str_rot13[\( \t]+)|(gzinflate[\( \t]+)|(gzuncompress[\( \t]+)|(strrev[\( \t]+)|(gzdecode[\( \t]+))+/
+
+    condition:
+        all of them
+}
+


### PR DESCRIPTION
These rules cover three shell types:

1. Those obfuscated by the Free Online PHP Obfuscator. We key off the "base64_decode" that is written in a mix of octal and hex.

2. Generic JSP. Blogged about this one. This simply detects execution of a request param. This code lead to some FP... but I'd argue that passing a request param to exec is always bad.

3. The last one detects a typical PHP obfuscation idiom, in which eval() is provided a bunch of deobfuscator functions (ie. gzinflate, base64_decode, rot13).