### PR TITLE
PHP Obfuscation techniques: chr() and urldecode()

### DIFF
--- a/webshells/obfuscated_php.yar
+++ b/webshells/obfuscated_php.yar
@@ -15,3 +15,18 @@ rule eval_statement
         all of them
 }
 
+rule hardcoded_urldecode
+{
+    meta:
+        description = "PHP with hard coded urldecode call"
+        family = "PHP.Obfuscated"
+        filetype = "PHP"
+        hash = "79b22d7dbf49d8cfdc564936c8a6a1e2"
+        hash = "38dc8383da0859dca82cf0c943dbf16d"
+
+    strings:
+        $obf = /urldecode[\t ]*\([\t ]*'(%[0-9a-fA-F][0-9a-fA-F])+'[\t ]*\)/
+
+    condition:
+        all of them
+}

--- a/webshells/obfuscated_php.yar
+++ b/webshells/obfuscated_php.yar
@@ -30,3 +30,20 @@ rule hardcoded_urldecode
     condition:
         all of them
 }
+
+rule chr_obfuscation
+{
+    meta:
+        description = "PHP with string building using hard coded values in chr()"
+        family = "PHP.Obfuscated"
+        filetype = "PHP"
+        hash = "d771409e152d0fabae45ea192076d45e"
+        hash = "543624bec87272974384c8ab77f2357a"
+        hash = "cf2ab009cbd2576a806bfefb74906fdf"
+
+    strings:
+        $obf = /\$[^=]+=[\t ]*(chr\([0-9]+\)\.?){2,}/
+
+    condition:
+        all of them
+}


### PR DESCRIPTION
This pull requests adds two generic obfuscation techniques commonly found in PHP webshells. The first flags files that use chr() to build up strings that can then be executed as a function. A great example here:

https://github.com/tennc/webshell/blob/master/php/%E8%BF%87%E5%90%84%E5%A4%A7%E6%9D%80%E8%BD%AF%E7%9A%84pHp%E4%B8%80%E5%8F%A5%E8%AF%9D.php

The other rule simply catches those that use urldecode() to hide their strings. A fine example can be seen here:

https://github.com/tennc/webshell/blob/master/php/ghost.php